### PR TITLE
Fix channel polarity setting and sync drive edge

### DIFF
--- a/firmware/common/rtl/FanInBoard.vhd
+++ b/firmware/common/rtl/FanInBoard.vhd
@@ -303,9 +303,17 @@ begin
       if rising_edge(renaCLk) then
          if renaClkRst = '1' then
             syncTmp    <= '0';
-            syncOut    <= '0';
          else
             syncTmp    <= syncReg;
+         end if;
+     end if;
+   end process;
+
+   process (renaClk) begin
+      if falling_edge(renaCLk) then
+         if renaClkRst = '1' then
+            syncOut    <= '0';
+         else
             syncOut    <= syncTmp;
          end if;
      end if;

--- a/firmware/python/ucsc_hn/_RenaChannel.py
+++ b/firmware/python/ucsc_hn/_RenaChannel.py
@@ -116,6 +116,8 @@ class RenaChannel(pr.Device):
         self.add(pr.LocalVariable(name='Polarity',
                                   value=0,
                                   mode='RW',
+                                  localSet=self._setPolarity,
+                                  localGet=self._getPolarity,
                                   enum={0:'Negative',1:'Positive'},
                                   description='Channel Polarity'))
 
@@ -277,4 +279,18 @@ class RenaChannel(pr.Device):
         f.write(f"        Test_Enable = {self.TestInputEnable.value()}\n")
         f.write(f"        VRef = {vref}\n")
         f.write("}\n")
+
+    def _getPolarity(self):
+        asic = self.parent
+        board = asic.parent
+        array = board.parent
+
+        return array.DataDecoder.getChannelPolarity(board.board, asic.rena, self.channel)
+
+    def _setPolarity(self, value):
+        asic = self.parent
+        board = asic.parent
+        array = board.parent
+
+        array.DataDecoder.setChannelPolarity(board.board, asic.rena, self.channel, value)
 

--- a/software/lib/src/RenaDataDecoder.cpp
+++ b/software/lib/src/RenaDataDecoder.cpp
@@ -55,12 +55,12 @@ void ucsc_hn_lib::RenaDataDecoder::countReset () {
 }
 
 void ucsc_hn_lib::RenaDataDecoder::setChannelPolarity(uint8_t fpga, uint8_t rena, uint8_t chan, bool state) {
-   if ( fpga > 29 || rena > 1 || chan > 25 ) return;
+   if ( fpga > 29 || rena > 1 || chan > 35 ) return;
    polarity_[fpga][rena][chan] = state;
 }
 
 bool ucsc_hn_lib::RenaDataDecoder::getChannelPolarity(uint8_t fpga, uint8_t rena, uint8_t chan) {
-   if ( fpga > 29 || rena > 1 || chan > 25 ) return false;
+   if ( fpga > 29 || rena > 1 || chan > 35 ) return false;
    return polarity_[fpga][rena][chan];
 }
 


### PR DESCRIPTION
Fixes the channel configuration so that it properly set polarity in data decoder.

Move sync output drive to falling edge.
